### PR TITLE
fix: harden upstream version sync

### DIFF
--- a/.github/workflows/sync-version-with-upstream.yml
+++ b/.github/workflows/sync-version-with-upstream.yml
@@ -22,11 +22,17 @@ jobs:
         with:
           token: ${{ secrets.SNAPCRAFTERS_BOT_COMMIT }}
           update-script: |
-            VERSION=$(
-              curl -sL "https://api.github.com/repos/audacity/audacity/releases" |
-              jq -r '.[] | select(.prerelease == false and .draft == false) | .tag_name' |
-              grep -v beta |
-              head -n 1 |
-              sed 's/^Audacity-//'
+            TAG=$(
+              curl --fail --silent --show-error --location \
+                "https://api.github.com/repos/audacity/audacity/releases/latest" |
+                jq --exit-status --raw-output \
+                  '.tag_name | select(type == "string" and startswith("Audacity-"))'
             )
+            VERSION="${TAG#Audacity-}"
+
+            if [[ ! "$VERSION" =~ ^[0-9]+([.][0-9]+){2}([+-][0-9A-Za-z.-]+)?$ ]]; then
+              echo "Invalid upstream version: $VERSION" >&2
+              exit 1
+            fi
+
             sed -i 's/^\(version: \).*$/\1'"$VERSION"'/' snap/snapcraft.yaml


### PR DESCRIPTION
## Summary

- use GitHub's stable `releases/latest` endpoint instead of filtering an unvalidated release list
- fail on HTTP errors and malformed, missing, or unexpected release tags
- validate the normalized version before editing `snap/snapcraft.yaml`

## Context

The scheduled Update run [32633314489](https://github.com/snapcrafters/audacity/actions/runs/32633314489) received a top-level JSON string from the releases endpoint, so `jq` failed with `Cannot index string with string "prerelease"`. The following scheduled run succeeded, which points to a transient upstream/API response, but the updater lacked explicit HTTP, shape, and version guards.

## Verification

- `actionlint .github/workflows/sync-version-with-upstream.yml`
- parsed the workflow with `yq`
- exercised valid stable/prerelease-form tags and malformed fixtures (API error object, null/empty/missing tag, wrong prefix, unsafe version, array, and top-level string)
- checked the live endpoint resolves to `Audacity-3.7.8`
- `git diff --check`

@jnsgruk
