### PR TITLE
fix: avoid conflicts with libs from mesa-2404 snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -57,6 +57,13 @@ layout:
     bind: $SNAP_COMMON/models/openvino-models
   /etc/gitconfig:
     bind-file: $SNAP_DATA/etc/gitconfig
+  /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/intel-opencl:
+    bind: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/intel-opencl
+
+package-repositories:
+  - type: apt
+    ppa: kobuk-team/intel-graphics
+    key-id: 0C0E6AF955CE463C03FC51574D098D70AFBE5E1F
 
 plugs:
   ffmpeg-2404:
@@ -150,43 +157,28 @@ parts:
         strip --strip-unneeded ${CRAFT_PART_INSTALL}/usr/local/libtorch/lib/*.a
       fi
 
-  opencl:
-    # Includes all the compute runtime and OpenCL bits needed for Intel GPU support
+  intel-graphics:
     plugin: nil
-    build-packages:
-      - wget
-    override-build: |
-      if [ "$CRAFT_ARCH_BUILD_FOR" == "amd64" ]; then
-        mkdir -p neo
-        cd neo
-        # Install Intel graphics compiler and compute runtime
-        # This is required to enable GPU support for OpenVINO
-        # https://docs.openvino.ai/2024/get-started/configurations/configurations-intel-gpu.html
-        intel_graphics_compiler_version="2.5.6"
-        intel_graphics_compiler_build="18417"
-        compute_runtime_version="24.52.32224.5"
-        wget https://github.com/intel/intel-graphics-compiler/releases/download/v${intel_graphics_compiler_version}/intel-igc-core-2_${intel_graphics_compiler_version}+${intel_graphics_compiler_build}_amd64.deb
-        wget https://github.com/intel/intel-graphics-compiler/releases/download/v${intel_graphics_compiler_version}/intel-igc-opencl-2_${intel_graphics_compiler_version}+${intel_graphics_compiler_build}_amd64.deb
-        wget https://github.com/intel/compute-runtime/releases/download/${compute_runtime_version}/intel-level-zero-gpu_1.6.32224.5_amd64.deb
-        wget https://github.com/intel/compute-runtime/releases/download/${compute_runtime_version}/intel-opencl-icd_${compute_runtime_version}_amd64.deb
-        wget https://github.com/intel/compute-runtime/releases/download/${compute_runtime_version}/libigdgmm12_22.5.5_amd64.deb
-        dpkg --root=$CRAFT_PART_INSTALL --force-all -i *.deb
-        # update paths to the Intel Installable Client Drivers (ICDs) for OpenCL
-        intel_icd="${CRAFT_PART_INSTALL}"/etc/OpenCL/vendors/intel.icd
-        intel_icd_so_path=$(cat ${intel_icd})
-        base_path="/snap/${SNAPCRAFT_PROJECT_NAME}/current"
-        echo "${base_path}""${intel_icd_so_path}" > "${intel_icd}"
-        intel_legacy1_icd="${CRAFT_PART_INSTALL}"/etc/OpenCL/vendors/intel_legacy1.icd
-        if [ -f ${intel_legacy1_icd} ]; then
-          intel_legacy1_icd_so_path=$(cat ${intel_legacy1_icd})
-          echo "${base_path}""${intel_legacy1_icd_so_path}" > "${intel_legacy1_icd}"
-        fi
-        # fix broken sym links
-        cd "${CRAFT_PART_INSTALL}"
-        ln -sf "${base_path}"/usr/bin/ocloc-24.39.1 etc/alternatives/ocloc
-        ln -sf "${base_path}"/etc/alternatives/ocloc usr/bin/ocloc
-        craftctl default
-      fi
+    stage-packages:
+      - to amd64:
+        - libigc-tools
+        - libigc2
+        - libigdfcl2
+        - intel-ocloc
+        - intel-opencl-icd
+        - libze1
+        - libze-intel-gpu1
+        - libigdgmm12
+        # Note, these -dev packages deliver development sym links that
+        # may be dynamically loaded by Intel compute runtime drivers.
+        - libigc-dev
+        - libigdfcl-dev
+    prime:
+      - -usr/include
+      - -usr/share
+    organize:
+      # move ligigdgmm so it is not removed by mesa-2404 cleanup step in the gnome/GPU extension
+      usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libigdgmm.so*: usr/local/lib/
 
   whisper.cpp:
     after:


### PR DESCRIPTION
This fixes https://github.com/snapcrafters/audacity/issues/87.

The first thing this does is bumps the Intel graphics stack to newer versions and pulls the packages from the [kobuk-team/intel-graphics PPA](https://launchpad.net/~kobuk-team/+archive/ubuntu/intel-graphics), providing support for the latest and greatest Intel hardware.

The real fix for https://github.com/snapcrafters/audacity/issues/87 is moving libigdgmm from the intel-graphics PPA to a non-standard system path to ensure it does not get removed by the `gnome/gpu/cleanup` part that is added by the `gnome` extension. The intention of this part is to avoid conflicts and duplicate libs already delivered by `mesa-2404` snap, but in this case we need a more recent version of libigdgmm to support newer Intel hardware.

I have tested these changes on Intel Lunar Lake, Meteor Lake, and Alder Lake machines to ensure it fixes the problems and also does not introduce any regressions to older CPU models like Alder Lake.