### PR TITLE
Revert to 3.7.9

### DIFF
--- a/.github/workflows/sync-version-with-upstream.yml
+++ b/.github/workflows/sync-version-with-upstream.yml
@@ -2,8 +2,10 @@ name: Update
 
 on:
   # Runs at 10:00 UTC every day
-  schedule:
-    - cron:  '0 10 * * *'
+  # Disable until 4.0.0 is reliable
+  # See https://github.com/snapcrafters/audacity/issues/91
+  #schedule:
+  #  - cron:  '0 10 * * *'
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 

--- a/bin/fetch-models
+++ b/bin/fetch-models
@@ -141,6 +141,8 @@ Downloading Music Separation models from Hugging Face. Please be patient!
   silent git clone https://huggingface.co/Intel/demucs-openvino "${SEPARATION_TMP}"
   cd "${SEPARATION_TMP}"
   silent git checkout 97fc578fb57650045d40b00bc84c7d156be77547
+  silent git lfs install
+  silent git lfs pull
   mkdir -p "${SEPARATION}"
   cp "${SEPARATION_TMP}/htdemucs_v4."{bin,xml} "${SEPARATION}"
   rm -rf "${SEPARATION_TMP}"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: audacity
-version: 4.0.0
+version: 3.7.9
 adopt-info: audacity
 description: |
   Audacity® is a free, easy-to-use, multi-track audio editor and recorder for Windows,


### PR DESCRIPTION
This reverts the version to 3.7.9 until the 4.0.0 build is stable and reliable (see https://github.com/snapcrafters/audacity/issues/91) and disables the automation for bumping the version to the latest from upstream.

This additionally fixes an issue with the OpenVINO music separation plugin that occurs when a user installs these models first, resulting in a git-lfs environment that is uninitialized and thus does not download the complete model files. See https://github.com/intel/openvino-plugins-ai-audacity/issues/493